### PR TITLE
volume mount the vault-creds volume

### DIFF
--- a/pkg/apis/vaultwebhook.uswitch.com/v1alpha1/types.go
+++ b/pkg/apis/vaultwebhook.uswitch.com/v1alpha1/types.go
@@ -17,6 +17,7 @@ type DatabaseCredentialBinding struct {
 type DatabaseCredentialBindingSpec struct {
 	Database       string `json:"database"`
 	Role           string `json:"role"`
+	OutputPath     string `json:"outputPath"`
 	ServiceAccount string `json:"serviceAccount"`
 }
 

--- a/webhook.go
+++ b/webhook.go
@@ -36,8 +36,9 @@ type patchOperation struct {
 }
 
 type database struct {
-	database string
-	role     string
+	database   string
+	role       string
+	outputPath string
 }
 
 func (srv webHookServer) serve(w http.ResponseWriter, r *http.Request) {
@@ -194,7 +195,11 @@ func matchBindings(bindings []v1alpha1.DatabaseCredentialBinding, serviceAccount
 	matchedBindings := []database{}
 	for _, binding := range bindings {
 		if binding.Spec.ServiceAccount == serviceAccount {
-			matchedBindings = appendIfMissing(matchedBindings, database{role: binding.Spec.Role, database: binding.Spec.Database})
+			output := binding.Spec.OutputPath
+			if output == "" {
+				output = "/etc/database"
+			}
+			matchedBindings = appendIfMissing(matchedBindings, database{role: binding.Spec.Role, database: binding.Spec.Database, outputPath: output})
 		}
 	}
 	return matchedBindings


### PR DESCRIPTION
You can't create a kube resource that tries to volume mount a volume that doesn't already exist. So we need to mount the volume as well as creating it. 

Added a field of OutputPath to the binding so that you can specify the path that the volume will be mounted to.