### PR TITLE
fix multiple binding bug

### DIFF
--- a/vault.go
+++ b/vault.go
@@ -181,8 +181,8 @@ func addVolumeMount(containers []corev1.Container, databases []database) []corev
 			}
 			//we don't want to mount the same path twice
 			container.VolumeMounts = appendVolumeMountIfMissing(container.VolumeMounts, volumeMount)
-			modifiedContainers = append(modifiedContainers, container)
 		}
+		modifiedContainers = append(modifiedContainers, container)
 	}
 
 	return modifiedContainers


### PR DESCRIPTION
We were creating duplicate containers by appending for each database instead of each container. This only happened when using multiple database bindings for a single pod