### PR TITLE
flag to set secret path format

### DIFF
--- a/main.go
+++ b/main.go
@@ -18,9 +18,10 @@ import (
 )
 
 var (
-	vaultAddr    string
-	loginPath    string
-	sidecarImage string
+	vaultAddr        string
+	loginPath        string
+	secretPathFormat string
+	sidecarImage     string
 )
 
 func main() {
@@ -28,6 +29,7 @@ func main() {
 	kingpin.Flag("vault-address", "URL of vault").Required().StringVar(&vaultAddr)
 	kingpin.Flag("login-path", "Kubernetes auth login path for vault").Required().StringVar(&loginPath)
 	kingpin.Flag("sidecar-image", "Vault-creds sidecar image to use").Required().StringVar(&sidecarImage)
+	kingpin.Flag("secret-path-format", "The format for the path used for reading database credentials, where the first %s is the database name and the second %s is the role").Default("%s/creds/%s").StringVar(&secretPathFormat)
 	kingpin.Parse()
 	log.SetOutput(os.Stderr)
 

--- a/vault.go
+++ b/vault.go
@@ -30,7 +30,7 @@ func addVault(pod *corev1.Pod, namespace, serviceAccountToken string, databases 
 
 		authRole := fmt.Sprintf("%s_%s_%s", database, namespace, serviceAccount)
 		containerName := fmt.Sprintf("vault-creds-%s-%s", strings.Replace(database, "_", "-", -1), role)
-		secretPath := fmt.Sprintf("database/creds/%s_%s", database, role)
+		secretPath := fmt.Sprintf(secretPathFormat, database, role)
 		templatePath := fmt.Sprintf("/creds/template/%s-%s", database, role)
 		var outputPath string
 


### PR DESCRIPTION
This allows you to pass the format for the secret path it should read from

e.g: for database and role, test readonly `--secret-path-format="%s/creds/%s` would become test/creds/readonly. 