### PR TITLE
Add functionality to dynamically reloading of certs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/sirupsen/logrus v1.0.4-0.20170822132746-89742aefa4b2
 	gopkg.in/airbrake/gobrake.v2 v2.0.9 // indirect
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
+	gopkg.in/fsnotify.v1 v1.4.7
 	gopkg.in/gemnasium/logrus-airbrake-hook.v2 v2.1.2 // indirect
 	k8s.io/api v0.15.12
 	k8s.io/apimachinery v0.15.12

--- a/main.go
+++ b/main.go
@@ -34,7 +34,7 @@ func main() {
 	kingpin.Parse()
 	log.SetOutput(os.Stderr)
 
-	pair, err := tls.LoadX509KeyPair("/etc/webhook/certs/cert.pem", "/etc/webhook/certs/key.pem")
+	kpr, err := NewKeypairReloader("/etc/webhook/certs/cert.pem", "/etc/webhook/certs/key.pem")
 	if err != nil {
 		log.Errorf("Failed to load key pair: %v", err)
 	}
@@ -56,11 +56,13 @@ func main() {
 
 	watcher := NewListWatch(webhookClient)
 
+	srv := http.Server{Addr: fmt.Sprintf(":443")}
+
+	t := &tls.Config{GetCertificate: kpr.GetCertificateFunc()}
+	srv.TLSConfig = t
+
 	whsvr := webHookServer{
-		server: &http.Server{
-			Addr:      fmt.Sprintf(":443"),
-			TLSConfig: &tls.Config{Certificates: []tls.Certificate{pair}},
-		},
+		server:   &srv,
 		client:   client,
 		bindings: watcher,
 	}

--- a/main.go
+++ b/main.go
@@ -34,6 +34,7 @@ func main() {
 	kingpin.Parse()
 	log.SetOutput(os.Stderr)
 
+	// load certs
 	kpr, err := NewKeypairReloader("/etc/webhook/certs/cert.pem", "/etc/webhook/certs/key.pem")
 	if err != nil {
 		log.Errorf("Failed to load key pair: %v", err)
@@ -58,6 +59,7 @@ func main() {
 
 	srv := http.Server{Addr: fmt.Sprintf(":443")}
 
+	// this will check if there are new certs before every tls handshake
 	t := &tls.Config{GetCertificate: kpr.GetCertificateFunc()}
 	srv.TLSConfig = t
 

--- a/tlsutil.go
+++ b/tlsutil.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"crypto/tls"
+	"log"
+	"sync"
+
+	"gopkg.in/fsnotify.v1"
+)
+
+type keypairReloader struct {
+	certMu   sync.RWMutex
+	cert     *tls.Certificate
+	certPath string
+	keyPath  string
+}
+
+func NewKeypairReloader(certPath, keyPath string) (*keypairReloader, error) {
+	result := &keypairReloader{
+		certPath: certPath,
+		keyPath:  keyPath,
+	}
+	cert, err := tls.LoadX509KeyPair(certPath, keyPath)
+	if err != nil {
+		return nil, err
+	}
+	result.cert = &cert
+
+	// creates a new file watcher
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, err
+	}
+
+	defer func() {
+		if err != nil {
+			watcher.Close()
+		}
+	}()
+
+	if err := watcher.Add("/etc/webhook/certs"); err != nil {
+		return nil, err
+	}
+
+	go func() {
+		for {
+			select {
+			// watch for events
+			case event := <-watcher.Events:
+				if event.Op&fsnotify.Create == fsnotify.Create {
+					log.Printf("Reloading certs")
+					if err := result.reload(); err != nil {
+						log.Printf("Could not load new certs: %v", err)
+					}
+				}
+
+				// watch for errors
+			case err := <-watcher.Errors:
+				log.Print("error", err)
+			}
+		}
+	}()
+
+	return result, nil
+}
+
+func (kpr *keypairReloader) reload() error {
+	newCert, err := tls.LoadX509KeyPair(kpr.certPath, kpr.keyPath)
+	if err != nil {
+		return err
+	}
+	kpr.certMu.Lock()
+	defer kpr.certMu.Unlock()
+	kpr.cert = &newCert
+	return nil
+}
+
+func (kpr *keypairReloader) GetCertificateFunc() func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
+	return func(clientHello *tls.ClientHelloInfo) (*tls.Certificate, error) {
+		kpr.certMu.RLock()
+		defer kpr.certMu.RUnlock()
+		return kpr.cert, nil
+	}
+}


### PR DESCRIPTION
### how does it work?

* cert-manager or any other mechanism updates the certs in secrets, `fsnotify` watcher will watch at `/etc/webhook/certs` (where secrets are mounted) and triggers an event if certs are updated

* Once, certs are updated,  [reload](https://github.com/uswitch/vault-webhook/pull/26/files#diff-5f87e88c87cd31b96ac1f66341224312R67) function will again reload new certs

* callback hook `GetCertificate` in `tls.Config` is used to get the new certs

### potential downtime

* when secrets are updated, it takes around 30-40 seconds to reflect new certs inside the pod

### Reference

* https://stackoverflow.com/a/40883377/7804592