### PR TITLE
Make the path to vault ca configurable

### DIFF
--- a/main.go
+++ b/main.go
@@ -30,7 +30,7 @@ var (
 func main() {
 
 	kingpin.Flag("vault-address", "URL of vault").Required().StringVar(&vaultAddr)
-	kingpin.Flag("vault-ca-path", "Path to the CA cert for vault").Default("/vault.ca").StringVar(&vaultCaPath)
+	kingpin.Flag("vault-ca-path", "Path to the CA cert for vault").StringVar(&vaultCaPath)
 	kingpin.Flag("login-path", "Kubernetes auth login path for vault").Required().StringVar(&loginPath)
 	kingpin.Flag("sidecar-image", "Vault-creds sidecar image to use").Required().StringVar(&sidecarImage)
 	kingpin.Flag("gateway-address", "URL of Push Gateway").StringVar(&gatewayAddr)

--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ import (
 
 var (
 	vaultAddr        string
+	vaultCaPath      string
 	gatewayAddr      string
 	loginPath        string
 	secretPathFormat string
@@ -29,6 +30,7 @@ var (
 func main() {
 
 	kingpin.Flag("vault-address", "URL of vault").Required().StringVar(&vaultAddr)
+	kingpin.Flag("vault-ca-path", "Path to the CA cert for vault").Default("/vault.ca").StringVar(&vaultCaPath)
 	kingpin.Flag("login-path", "Kubernetes auth login path for vault").Required().StringVar(&loginPath)
 	kingpin.Flag("sidecar-image", "Vault-creds sidecar image to use").Required().StringVar(&sidecarImage)
 	kingpin.Flag("gateway-address", "URL of Push Gateway").StringVar(&gatewayAddr)

--- a/vault.go
+++ b/vault.go
@@ -61,7 +61,7 @@ func addVault(pod *corev1.Pod, namespace, serviceAccountToken string, databases 
 			Args: []string{
 				"--vault-addr=" + vaultAddr,
 				"--gateway-addr=" + gatewayAddr,
-				"--ca-cert=/vault.ca",
+				"--ca-cert=" + vaultCaPath,
 				"--secret-path=" + secretPath,
 				"--login-path=" + loginPath,
 				"--auth-role=" + authRole,


### PR DESCRIPTION
The path to the CA cert to be used with vault is currently hardcoded to `/vault.ca` but it would be useful to be able to configure this.