### PR TITLE
Updates CRD to v1

### DIFF
--- a/crd.yaml
+++ b/crd.yaml
@@ -1,26 +1,29 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: databasecredentialbindings.vaultwebhook.uswitch.com
 spec:
   group: vaultwebhook.uswitch.com
-  version: v1alpha1
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          properties:
+            spec:
+              properties:
+                database:
+                  type: string
+                role:
+                  type: string
+                outputPath:
+                  type: string
+                outputFile:
+                  type: string
   names:
     kind: DatabaseCredentialBinding
     plural: databasecredentialbindings
     shortNames:
       - dcb
   scope: Namespaced
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          properties:
-            database:
-              type: string
-            role:
-              type: string
-            outputPath:
-               type: string
-            outputFile:
-               type: string


### PR DESCRIPTION
## Overview
The apiextensions.k8s.io/v1beta1 API version of CustomResourceDefinition [is no longer served as of Kubernetes v1.22](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#customresourcedefinition-v122).

## Changes
- updates `databasecredentialbindings.vaultwebhook.uswitch.com` CRD to `v1`