### PR TITLE
AIRSHIP-2513 Make port configurable and default to 8443

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,21 @@ spec:
         configMap:
           name: my-template
 ```
+
+## Args
+
+```sh
+usage: vault-webhook-linux-amd64 --vault-address=VAULT-ADDRESS --login-path=LOGIN-PATH --sidecar-image=SIDECAR-IMAGE [<flags>]
+
+Flags:
+  --help                         Show context-sensitive help (also try --help-long and --help-man).
+  --vault-address=VAULT-ADDRESS  URL of vault
+  --vault-ca-path=VAULT-CA-PATH  Path to the CA cert for vault
+  --login-path=LOGIN-PATH        Kubernetes auth login path for vault
+  --sidecar-image=SIDECAR-IMAGE  Vault-creds sidecar image to use
+  --gateway-address=GATEWAY-ADDRESS
+                                 URL of Push Gateway
+  --secret-path-format="%s/creds/%s"
+                                 The format for the path used for reading database credentials, where the first %s is the database name and the second %s is the role
+  --server-address=":8443"       The address the webhook server will listen on.
+```

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ spec:
 
 ## Args
 
-```sh
+```ShellSession
 usage: vault-webhook-linux-amd64 --vault-address=VAULT-ADDRESS --login-path=LOGIN-PATH --sidecar-image=SIDECAR-IMAGE [<flags>]
 
 Flags:

--- a/main.go
+++ b/main.go
@@ -24,6 +24,7 @@ var (
 	loginPath        string
 	secretPathFormat string
 	sidecarImage     string
+	serverAddress    string
 )
 
 func main() {
@@ -34,6 +35,7 @@ func main() {
 	kingpin.Flag("sidecar-image", "Vault-creds sidecar image to use").Required().StringVar(&sidecarImage)
 	kingpin.Flag("gateway-address", "URL of Push Gateway").StringVar(&gatewayAddr)
 	kingpin.Flag("secret-path-format", "The format for the path used for reading database credentials, where the first %s is the database name and the second %s is the role").Default("%s/creds/%s").StringVar(&secretPathFormat)
+	kingpin.Flag("server-address", "The address the webhook server will listen on.").Default(":8443").StringVar(&serverAddress)
 	kingpin.Parse()
 	log.SetOutput(os.Stderr)
 
@@ -62,7 +64,7 @@ func main() {
 
 	watcher := NewListWatch(webhookClient)
 
-	srv := http.Server{Addr: fmt.Sprintf(":443")}
+	srv := http.Server{Addr: serverAddress}
 
 	// this will check if there are new certs before every tls handshake
 	t := &tls.Config{GetCertificate: kpr.GetCertificateFunc()}


### PR DESCRIPTION
The Vault Webhook server previously used `:443` as the bind address. As the image was recently moved to use a non-root user this now breaks on startup so we've added the ability to customize the port and defaulted to `8443` instead.

*This is breaking change as the default has changed.*