### PR TITLE
Skip pod mutation if vault agent inject annotation present

### DIFF
--- a/webhook.go
+++ b/webhook.go
@@ -120,6 +120,14 @@ func (srv webHookServer) mutate(ar *v1beta1.AdmissionReview) *v1beta1.AdmissionR
 		ownerKind = pod.ObjectMeta.OwnerReferences[0].Kind
 		ownerName = pod.ObjectMeta.OwnerReferences[0].Name
 	}
+
+	if pod.ObjectMeta.Annotations["vault.hashicorp.com/agent-inject"] == "true" {
+		log.Infof("Skipping mutation for %s/%s, vault agent-inject annotation found", req.Namespace, ownerName)
+		return &v1beta1.AdmissionResponse{
+			Allowed: true,
+		}
+	}
+
 	log.Infof("AdmissionReview for Kind=%v, Namespace=%v Name=%v UID=%v patchOperation=%v UserInfo=%v",
 		ownerKind, req.Namespace, ownerName, req.UID, req.Operation, req.UserInfo)
 


### PR DESCRIPTION
Adding logic to skip pod mutation if `vault.hashicorp.com/agent-inject=true` annotation is set on the pod. 

This is to enable a migration from [uswitch/vault-webhook](https://github.com/uswitch/vault-webhook/) to [hashicorp/vault-k8s](https://github.com/hashicorp/vault-k8s). This annotation is set when using vault-k8s so when it is set, vault-k8s should handle adding the sidecar.