### PR TITLE
change to pull vault-creds sidecar IfNotPresent

### DIFF
--- a/vault.go
+++ b/vault.go
@@ -55,7 +55,7 @@ func addVault(pod *corev1.Pod, namespace string, databases []database) (patch []
 
 		vaultContainer := corev1.Container{
 			Image:           sidecarImage,
-			ImagePullPolicy: "Always",
+			ImagePullPolicy: "IfNotPresent",
 			Resources: corev1.ResourceRequirements{
 				Requests: requests,
 				Limits:   limits,


### PR DESCRIPTION
Quay.io is degraded so changing to only pull if image is not already present to reduce the number of pulls.